### PR TITLE
feature: 사진 촬영 페이지 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "autoprefixer": "^10.4.21",
     "axios": "^1.7.8",
+    "dotenv": "^16.5.0",
     "postcss": "^8.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/css/picture.css
+++ b/src/css/picture.css
@@ -7,9 +7,7 @@
 }
 video {
     width: 350px !important;
-    height: 479px !important;
-    margin-bottom: 20px;
-    margin-left: 400px;
+    height: 419px !important;
 }
 .flash {
     position: fixed;
@@ -184,7 +182,7 @@ video {
 .countdown {
     position: absolute;
     top: 50%;
-    left: 30%;
+    left: 50%;
     transform: translate(-50%, -50%);
     font-size: 100px; /* 글자 크기 */
     font-weight: bold;

--- a/src/pages/PictureCompletedPage.js
+++ b/src/pages/PictureCompletedPage.js
@@ -47,7 +47,7 @@ const PictureCompletedPage = () => {
                         {photoUrls.map((url, index) => (
                             <div key={index}>
                                 <img className="width-150px height-150px margin-bottom-10px"
-                                    src={process.env.BACKEND_URL + `/file?date=${url.split("_")[2]}_${url.split("_")[3]}&groupid=${url.split("_")[1]}&index=${index+1}`}
+                                    src={process.env.REACT_APP_BACKEND_URL + `/photos/group/${groupid}/${index+1}`}
                                     alt={`사진 ${index + 1}`}
                                 />
                             </div>

--- a/src/pages/PicturePage.js
+++ b/src/pages/PicturePage.js
@@ -123,10 +123,8 @@ const PicturePage = ({ setTeamId }) => {
 
     const uploadPhotos = async (formData) => {
         try {
-            const response = await axios.post(process.env.BACKEND_URL + "/origin-upload", formData, {
-                headers: {
-                    "Content-Type": "multipart/form-data",
-                },
+            const response = await axios.post(process.env.REACT_APP_BACKEND_URL + "/photos", formData, {
+                headers: { "Content-Type": "multipart/form-data" },
             });
             console.log("Upload response:", response.data);
             navigate("/picture/completed", {

--- a/src/pages/PicturePage.js
+++ b/src/pages/PicturePage.js
@@ -2,12 +2,12 @@ import React, { useRef, useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import axios from "axios";
 import "../css/picture.css";
-import logo1 from "../images/icons/stack_dev_logo2.png";
-import logo2 from "../images/icons/camera_icon.png";
-import logo3 from "../images/icons/PictureCompletedPage_imoticon.png";
-import chickpeasImage from "../images/icons/chickpeas_2.png";
 import cameraSound from "../sound/camera-shutter.mp3";
-
+import { OuterLayout, PageTitle } from "../components/layout/CommonLayout";
+import StepIndicator from "../components/step/StepIndicator";
+import InnerBox from "../components/layout/InnerBox";
+import Button from "../components/common/Button";
+import { useCameraStore } from "../store/useCameraStore";
 /**
  * 메인 페이지
  * @since
@@ -25,6 +25,7 @@ const PicturePage = ({ setTeamId }) => {
     const [photoNumber, setPhotoNumber] = useState(1);
     const [searchParams] = useSearchParams();
 
+    const { stream, startCamera, stopCamera } = useCameraStore();
     const frameid = searchParams.get("frameid");
     const groupid = searchParams.get("groupid");
     const date = searchParams.get("date");
@@ -39,86 +40,74 @@ const PicturePage = ({ setTeamId }) => {
     };
     const { width, height } = frameSizes[frameid];
 
-    const startCamera = async () => {
+    const initializeCamera = async () => {
         try {
-            const stream = await navigator.mediaDevices.getUserMedia({
-                video: { width, height, facingMode: "user" },
-            });
+            const newStream = await startCamera({ video: { width, height, facingMode: "user" }, audio: false });
             if (videoRef.current) {
-                videoRef.current.srcObject = stream;
+                videoRef.current.srcObject = newStream;
+                await videoRef.current.play();
+                setIsCameraStarted(true);
+                captureAndUploadPhotos();
             }
-            setIsCameraStarted(true);
         } catch (err) {
-            console.error("카메라 접근에 실패했습니다:", err);
+            console.error("카메라 접근 실패:", err);
+            alert("카메라 접근에 실패했습니다: " + err.name + " - " + err.message);
         }
     };
 
     const triggerFlash = () => {
         if (flashRef.current) {
             flashRef.current.classList.add("active");
-            setTimeout(() => {
-                flashRef.current.classList.remove("active");
-            }, 200);
+            setTimeout(() => flashRef.current.classList.remove("active"), 200);
         }
     };
 
     const playShutterSound = () => {
         const sound = new Audio(cameraSound);
         sound.load();
-        sound.play().catch((err) => console.error("Audio playback failed:", err)); // 에러 핸들링
+        sound.play().catch((err) => console.error("Audio playback failed:", err));
     };
 
     const captureAndUploadPhotos = async () => {
-        setIsCapturing(true);
-        const photoCount = 6;
-        const formData = new FormData();
+        try {
+            setIsCapturing(true);
+            const formData = new FormData();
+            for (let i = 0; i < 6; i++) {
+                setPhotoNumber(i + 1);
+                for (let j = 5; j > 0; j--) {
+                    setCountdown(j);
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                }
+                setCountdown(null);
 
-        for (let i = 0; i < photoCount; i++) {
-            setPhotoNumber(i + 1); // 현재 촬영 중인 사진 번호 업데이트
-            for (let j = 5; j > 0; j--) {
-                setCountdown(j);
+                if (videoRef.current && canvasRef.current) {
+                    const context = canvasRef.current.getContext("2d");
+                    canvasRef.current.width = videoRef.current.videoWidth;
+                    canvasRef.current.height = videoRef.current.videoHeight;
+                    context.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+                    context.translate(canvasRef.current.width, 0);
+                    context.scale(-1, 1);
+                    context.drawImage(videoRef.current, 0, 0);
+                    const blob = await new Promise((resolve, reject) => {
+                        canvasRef.current.toBlob((blob) => {
+                            if (!blob) reject("toBlob 실패");
+                            else resolve(blob);
+                        }, "image/png");
+                    });
+                    formData.append("images", blob, `photo_${i + 1}.png`);
+                }
+
+                triggerFlash();
+                playShutterSound();
                 await new Promise((resolve) => setTimeout(resolve, 1000));
             }
-            setCountdown(null);
 
-            if (videoRef.current && canvasRef.current) {
-                const context = canvasRef.current.getContext("2d");
-                canvasRef.current.width = videoRef.current.videoWidth;
-                canvasRef.current.height = videoRef.current.videoHeight;
-
-                context.translate(canvasRef.current.width, 0);
-                context.scale(-1, 1);
-                context.drawImage(
-                    videoRef.current,
-                    0,
-                    0,
-                    canvasRef.current.width,
-                    canvasRef.current.height
-                );
-
-                const blob = await new Promise((resolve) => {
-                    canvasRef.current.toBlob(resolve, "image/png");
-                });
-
-                if (blob) {
-                    formData.append("images", blob, `photo_${i + 1}.png`);
-                } else {
-                    console.error("Blob creation failed");
-                    setIsCapturing(false);
-                    return;
-                }
-            }
-
-            triggerFlash();
-            playShutterSound();
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            const uploadResult = await uploadPhotos(formData);
+            if (!uploadResult) console.error("사진 업로드 실패");
+            setIsCapturing(false);
+        } catch (e) {
+            alert(e);
         }
-
-        const uploadResult = await uploadPhotos(formData);
-        if (!uploadResult) {
-            console.error("사진 업로드에 문제가 있습니다.");
-        }
-        setIsCapturing(false);
     };
 
     const uploadPhotos = async (formData) => {
@@ -126,12 +115,8 @@ const PicturePage = ({ setTeamId }) => {
             const response = await axios.post(process.env.REACT_APP_BACKEND_URL + "/photos", formData, {
                 headers: { "Content-Type": "multipart/form-data" },
             });
-            console.log("Upload response:", response.data);
             navigate("/picture/completed", {
-                state: {
-                    data: response.data,
-                    frameid: frameid,
-                },
+                state: { data: response.data, frameid: frameid },
             });
             return response.data;
         } catch (err) {
@@ -141,67 +126,52 @@ const PicturePage = ({ setTeamId }) => {
         }
     };
 
+    useEffect(() => {
+        return () => {
+            stopCamera();
+        };
+    }, []);
+
     return (
-        <div className="camera-container background-yellow">
-            <div ref={flashRef} className="flash"></div>
-            {/* 플래시 효과 */}
-            <div className="header">
-                <img
-                    src={logo1}
-                    alt="Stack Logo"
-                    className="stack_logo"
-                    onClick={() => {
-                        navigate("/");
-                    }}
-                />
-            </div>
-            {!isCameraStarted && <img src={logo3} alt="imoticon" className="imoticon" />}
-            {isCameraStarted && isCapturing && (
-                <div className="photo-number-indicator">
-                    <h2>{`촬영 ${photoNumber} / 6`}</h2>
+        <OuterLayout>
+            <StepIndicator currentStep={2} stepCount={3} />
+            <InnerBox className="p-8">
+                <PageTitle>사진을<br /><span>촬영</span>해주세요</PageTitle>
+                <div ref={flashRef} className="flash" />
+                <div className={`w-full h-full px-16 flex flex-col ${isCapturing ? "" : "pb-4"}`}>
+                    <div className={`w-full flex flex-row justify-center items-center ${isCapturing ? "" : "h-full"}`}>
+                        <video
+                            ref={videoRef}
+                            key={frameid}
+                            autoPlay
+                            playsInline
+                            style={{
+                                width: `${width}px`,
+                                transform: "scaleX(-1)",
+                                display: `${isCapturing ? "block" : "none"}`
+                            }}
+                        ></video>
+                        <div className="w-full h-full bg-[#EFEFEF] flex flex-col justify-center border-2 border-[#AAAAAA]"
+                            style={{ display: `${isCapturing ? "none" : "flex"}`}}>
+                            <div className="w-full flex flex-row justify-center">
+                                <Button type="default" onClick={initializeCamera}>
+                                    사진 촬영하기
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                    <PageTitle className={`${isCameraStarted ? "" : "hidden"} py-6`}>
+                        <span>{photoNumber}</span> / 6
+                    </PageTitle>
                 </div>
-            )}
-            <video
-                ref={videoRef}
-                autoPlay
-                playsInline
-                style={{
-                    width: `${width}px`,
-                    height: `${height}px`,
-                    marginBottom: "20px",
-                    transform: "scaleX(-1)",
-                }}
-            ></video>
-
-            <canvas ref={canvasRef} style={{ display: "none" }}></canvas>
-
-            {countdown && (
-                <div className="countdown">
-                    <h1>{countdown}</h1>
-                </div>
-            )}
-
-            <div className="camera-button-container">
-                {!isCameraStarted && (
-                    <button className="camera-start-button weight-500" onClick={startCamera}>
-                        사진 촬영
-                    </button>
+                <canvas ref={canvasRef} style={{ display: "none" }}></canvas>
+                {countdown && (
+                    <div className="countdown">
+                        <h1>{countdown}</h1>
+                    </div>
                 )}
-                {isCameraStarted && (
-                    <>
-                        <img src={chickpeasImage} alt="Chickpeas Icon" className="chickpeas-icon" />
-                        <button
-                            className={`camera-button weight-500`}
-                            onClick={captureAndUploadPhotos}
-                            disabled={isCapturing}
-                        >
-                            {isCapturing ? "촬영 중..." : "사진 촬영"}{" "}
-                            <img src={logo2} alt="Camera icon" className="camera-icon" />
-                        </button>
-                    </>
-                )}
-            </div>
-        </div>
+            </InnerBox>
+        </OuterLayout>
     );
 };
 

--- a/src/pages/SelectPhotoPage.js
+++ b/src/pages/SelectPhotoPage.js
@@ -54,12 +54,12 @@ const SelectPhotoPage = () => {
 
         // PictureCompletedPage에서 넘겨주는 쿼리파라미터 date, groupid값으로 file api 이용해서 이미지 불러오기
         setPhotos([
-            process.env.BACKEND_URL + `/file?date=`+date+`&type=original&groupid=`+groupid+`&index=1`,
-            process.env.BACKEND_URL + `/file?date=`+date+`&type=original&groupid=`+groupid+`&index=2`,
-            process.env.BACKEND_URL + `/file?date=`+date+`&type=original&groupid=`+groupid+`&index=3`,
-            process.env.BACKEND_URL + `/file?date=`+date+`&type=original&groupid=`+groupid+`&index=4`,
-            process.env.BACKEND_URL + `/file?date=`+date+`&type=original&groupid=`+groupid+`&index=5`,
-            process.env.BACKEND_URL + `/file?date=`+date+`&type=original&groupid=`+groupid+`&index=6`,
+            process.env.REACT_APP_BACKEND_URL + `/photos/group/${groupid}/1`,
+            process.env.REACT_APP_BACKEND_URL + `/photos/group/${groupid}/2`,
+            process.env.REACT_APP_BACKEND_URL + `/photos/group/${groupid}/3`,
+            process.env.REACT_APP_BACKEND_URL + `/photos/group/${groupid}/4`,
+            process.env.REACT_APP_BACKEND_URL + `/photos/group/${groupid}/5`,
+            process.env.REACT_APP_BACKEND_URL + `/photos/group/${groupid}/6`,
         ]);
     }, [date,groupid,frameid]);//frameid,groupid에 종속적인 useEffect(), frameid,groupid를 받아와야 실행함
     const checkFrames = ()=>{
@@ -138,7 +138,7 @@ const SelectPhotoPage = () => {
 
 
             // 주소에 api 주소 적기
-            const response = await fetch(process.env.BACKEND_URL + "/upload", {
+            const response = await fetch(process.env.REACT_APP_BACKEND_URL + "/upload", {
                 method: "POST",
                 body: formData,
             });

--- a/src/pages/SuccessPage.js
+++ b/src/pages/SuccessPage.js
@@ -29,11 +29,11 @@ const SuccessPage = () => {
     const date = searchParams.get("date");
 
     useEffect(() => {
-        setImage(`${process.env.BACKEND_URL}/final_file?date=` + date + `&groupid=` + groupid);
+        setImage(`${process.env.REACT_APP_BACKEND_URL}/final_file?date=` + date + `&groupid=` + groupid);
     }, [groupid, date]);
 
     const get_QR = async () => {
-        const response = await fetch(`${process.env.BACKEND_URL}/create-qr?groupid=${groupid}&date=${date}`, { method: 'POST' });
+        const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/create-qr?groupid=${groupid}&date=${date}`, { method: 'POST' });
         if (response.ok) {
             const blob = await response.blob();
             const imageUrl = URL.createObjectURL(blob);

--- a/src/pages/TestPage.js
+++ b/src/pages/TestPage.js
@@ -7,7 +7,7 @@ const TestPage = () => {
     const [message, setMessage] = useState("");
 
     useEffect(() => {
-        const apiUrl = process.env.BACKEND_URL + `/test`;
+        const apiUrl = process.env.REACT_APP_BACKEND_URL + `/test`;
 
         fetch(apiUrl)
             .then(res => res.text())

--- a/src/store/useCameraStore.js
+++ b/src/store/useCameraStore.js
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+export const useCameraStore = create((set, get) => ({
+    stream: null,
+
+    startCamera: async (constraints = { video: { facingMode: "user" }, audio: false }) => {
+        const prevStream = get().stream;
+
+        // 기존 스트림 정리
+        if (prevStream) {
+            prevStream.getTracks().forEach((track) => track.stop());
+        }
+
+        // 새 스트림 요청
+        const newStream = await navigator.mediaDevices.getUserMedia(constraints);
+        set({ stream: newStream });
+
+        return newStream;
+    },
+
+    stopCamera: () => {
+        const currentStream = get().stream;
+        if (currentStream) {
+            currentStream.getTracks().forEach((track) => track.stop());
+            set({ stream: null });
+        }
+    },
+}));


### PR DESCRIPTION
## 🔎 관련 이슈
closed #40 

## 🔎 작업 내용
- 카메라 전역 상태 zustand 적용
- 사진 촬영 페이지 UI 개선

# 웹앱에서 카메라 불러와지지 않는 문제 개선

## 문제 상황

- 웹앱에서 카메라가 불러와지지 않음
- 이전 페이지로 돌아갔다가 다른 프레임을 선택하여 사진 촬영 페이지로 접속하면 카메라가 불러와지지 않음

## 웹앱에서 카메라가 불러와지지 않음

### 문제 원인

- 웹앱에서 카메라 접근 권한이 없음
- 카메라 호출, 카메라 실행을 하나의 로직으로 합치며 두 로직이 비동기적으로 실행됨
- 동시에 호출되었기 때문에 카메라 호출이 완료되기 전에 카메라 실행이 동작하여 오류 발생

### 문제 해결

- 웹앱에서는 앱 권한에서도 카메라 권한이 필요함
- 카메라 권한 요청을 명시적으로 요청해야 웹앱에서도 카메라 사용이 가능함
- 호출과 실행을 동기적으로 실행하여 문제 해결

## 이전 페이지로 돌아갔다가 다른 프레임을 선택하여 사진 촬영 페이지로 접속하면 카메라가 불러와지지 않음

### 문제 원인

- 한번 카메라를 호출하면 카메라를 계속해서 실행하고 있음
- 그 상황에서 카메라를 한번 더 호출하면 이미 카메라를 사용하는 프로세스가 있기 때문에 오류가 발생함

### 문제 해결

- 카메라의 전역 상태관리를 통해 카메라의 중복 호출을 방지함

## 🔎 참고사항
![image](https://github.com/user-attachments/assets/5af23644-2a22-4b7f-aafa-6015c1de7c5d)
![image](https://github.com/user-attachments/assets/c8428484-aec0-44fb-9586-a729cb96d804)
[사진 촬영 오류 개선](https://ehyune.notion.site/Stack4Cut-1fca0b09f7a38093ad29fed9b6013287?pvs=4)